### PR TITLE
Disable network namespace changes by default

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink/nlenc"
 )
 
 // errInvalidAttribute specifies if an Attribute's length is incorrect.

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink/nlenc"
 )
 
 func TestMarshalAttributes(t *testing.T) {

--- a/bench_test.go
+++ b/bench_test.go
@@ -3,7 +3,7 @@ package netlink_test
 import (
 	"testing"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 var attrBench = []struct {

--- a/conn.go
+++ b/conn.go
@@ -565,6 +565,14 @@ type Config struct {
 	// no multicast group subscriptions will be made.
 	Groups uint32
 
+	// DisableNSGoroutine disables the goroutine that allows switching to a different
+	// network namespace. This forces running netlink socket syscalls in the caller thread's netns.
+	//
+	// Users who manage namespace transitions manually, or do not require them at all should
+	// set this to true, otherwise overhead will be incurred due to context switches and channel communication
+	// for the executed system calls.
+	DisableNSGoroutine bool
+
 	// NetNS specifies the network namespace the Conn will operate in.
 	//
 	// If set (non-zero), Conn will enter the specified network namespace and

--- a/conn_linux_error_test.go
+++ b/conn_linux_error_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
-	"github.com/mdlayher/netlink/nltest"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nlenc"
+	"github.com/twistlock/netlink/nltest"
 	"golang.org/x/sys/unix"
 )
 

--- a/conn_linux_gteq_1.12_integration_test.go
+++ b/conn_linux_gteq_1.12_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jsimonetti/rtnetlink/rtnl"
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 	"golang.org/x/sys/unix"
 )
 

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nlenc"
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 )

--- a/conn_test.go
+++ b/conn_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nltest"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nltest"
 )
 
 func TestConnExecute(t *testing.T) {

--- a/example_attributedecoder_test.go
+++ b/example_attributedecoder_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 // decodeNested is a nested structure within decodeOut.

--- a/example_attributeencoder_test.go
+++ b/example_attributeencoder_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 // encodeNested is a nested structure within out.

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,9 @@ package netlink_test
 import (
 	"log"
 
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
-	"github.com/mdlayher/netlink/nltest"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nlenc"
+	"github.com/twistlock/netlink/nltest"
 )
 
 // This example demonstrates using a netlink.Conn to execute requests against

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mdlayher/netlink
+module github.com/twistlock/netlink
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4 h1:nwOc1YaOrYJ37sEBrtWZrdqzK22hiJs3GpDmP3sR2Yw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v1.0.0 h1:vySPY5Oxnn/8lxAPn2cK6kAzcZzYJl3KriSLO46OT18=
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/message.go
+++ b/message.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink/nlenc"
 )
 
 // Flags which may apply to netlink attribute types when communicating with

--- a/message_test.go
+++ b/message_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink/nlenc"
 )
 
 func TestHeaderFlagsString(t *testing.T) {

--- a/nltest/nltest.go
+++ b/nltest/nltest.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nlenc"
 )
 
 // PID is the netlink header PID value assigned by nltest.

--- a/nltest/nltest_linux_gteq_1.13_test.go
+++ b/nltest/nltest_linux_gteq_1.13_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nltest"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nltest"
 	"golang.org/x/sys/unix"
 )
 

--- a/nltest/nltest_test.go
+++ b/nltest/nltest_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nltest"
+	"github.com/twistlock/netlink"
+	"github.com/twistlock/netlink/nltest"
 )
 
 func TestConnSend(t *testing.T) {


### PR DESCRIPTION
This change introduces a config parameter to toggle the support of switching network namespaces.
By default the toggle will be disabled, and netlink sockets will be created within the network
namespace of the calling thread. If enabled, a goroutine will be created which will run in the
provided custom netns.